### PR TITLE
Map relationships in AgentSecureDbContext.cs

### DIFF
--- a/AgentSecure/Data/AgentSecureDbContext.cs
+++ b/AgentSecure/Data/AgentSecureDbContext.cs
@@ -16,6 +16,34 @@ namespace AgentSecure.Data
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
 
+      // Login => User (many-to-one)
+      modelBuilder.Entity<Login>()
+        .HasOne(l => l.User)
+        .WithMany(u => u.Logins)
+        .HasForeignKey(l => l.UserId)
+        .OnDelete(DeleteBehavior.Cascade);
+
+      // Login => Vendor (many-to-one)
+      modelBuilder.Entity<Login>()
+        .HasOne(l => l.Vendor)
+        .WithMany(v => v.Logins)
+        .HasForeignKey(l => l.VendorId)
+        .OnDelete(DeleteBehavior.Cascade);
+
+      // VendorCategory => Vendor (many-to-one)
+      modelBuilder.Entity<VendorCategory>()
+        .HasOne(vc => vc.Vendor)
+        .WithMany(v => VendorCategories)
+        .HasForeignKey(vc => vc.VendorId)
+        .OnDelete(DeleteBehavior.Cascade);
+
+      // VendorCateogry => Category (many-to-one)
+      modelBuilder.Entity<VendorCategory>()
+        .HasOne(vc => vc.Category)
+        .WithMany(c => c.VendorCategories)
+        .HasForeignKey(vc => vc.CategoryId)
+        .OnDelete(DeleteBehavior.Cascade);
+
       modelBuilder.Entity<Category>().HasData(CategoryData.Categories);
       modelBuilder.Entity<Login>().HasData(LoginData.Logins);
       modelBuilder.Entity<User>().HasData(UserData.Users);


### PR DESCRIPTION
**Description**

Mapped the following relationships in AgentSecureDbContext.cs:

- [ ] Login => User (many-to-one)
- [ ] Login => Vendor (many-to-one)
- [ ] VendorCategory => Vendor (many-to-one)
- [ ] VendorCategory => Category (many-to-one)


**Related Issue**

#40 


**Motivation and Context**

- [ ] The developer must be able to seed data into the database
- [ ] Users must be able to interact with data stored in the database


**How Can This Be Tested?**

Pull down and test manually


**Screenshots (if appropriate):**

N/A


**Types of changes**

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
