### PR TITLE
Created CreateVendorCategoryAsync call

### DIFF
--- a/AgentSecure/Endpoints/VendorCategoryEndpoints.cs
+++ b/AgentSecure/Endpoints/VendorCategoryEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using AgentSecure.Interfaces;
 using AgentSecure.Models;
+using AgentSecure.Services;
 
 namespace AgentSecure.Endpoint
 {
@@ -18,6 +19,20 @@ namespace AgentSecure.Endpoint
       var group = routes.MapGroup("/api/vendorcategories").WithTags(nameof(VendorCategory));
 
       // API calls
+
+      // Create VendorCategory
+      group.MapPost("/", async (VendorCategory vendorCategory, IAgentSecureVendorCategoryService agentSecureVendorCategoryService) =>
+      {
+        return await agentSecureVendorCategoryService.CreateVendorCategoryAsync(vendorCategory);
+      })
+      .WithName("CreateVendorCategory")
+      .WithOpenApi()
+      .Produces<VendorCategory>(StatusCodes.Status201Created)
+      .Produces(StatusCodes.Status400BadRequest);
+
+      // Delete VendorCategory
+
+
     }
   }
 }

--- a/AgentSecure/Interfaces/IAgentSecureCategoryRepository.cs
+++ b/AgentSecure/Interfaces/IAgentSecureCategoryRepository.cs
@@ -11,7 +11,7 @@ namespace AgentSecure.Interfaces
 
     // seed categories
     Task<List<Category>> GetAllCategoriesAsync();
-    Task<Category> GetCategoryByIdAsync(int id);
+    Task<Category?> GetCategoryByIdAsync(int id);
     Task<Category> CreateCategoryAsync(Category category);
     Task<Category> UpdateCategoryAsync(int id, Category category);
     Task<Category> DeleteCategoryAsync(int id);

--- a/AgentSecure/Interfaces/IAgentSecureCategoryService.cs
+++ b/AgentSecure/Interfaces/IAgentSecureCategoryService.cs
@@ -11,7 +11,7 @@ namespace AgentSecure.Interfaces
 
     // seed categories
     Task<List<Category>> GetAllCategoriesAsync();
-    Task<Category> GetCategoryByIdAsync(int id);
+    Task<Category?> GetCategoryByIdAsync(int id);
     Task<Category> CreateCategoryAsync(Category category);
     Task<Category> UpdateCategoryAsync(int id, Category category);
     Task<Category> DeleteCategoryAsync(int id);

--- a/AgentSecure/Interfaces/IAgentSecureVendorCategoryRepository.cs
+++ b/AgentSecure/Interfaces/IAgentSecureVendorCategoryRepository.cs
@@ -10,5 +10,6 @@ namespace AgentSecure.Interfaces
     // Interfaces can be used in unit testing to mock out the actual implementation.
 
     // seed categories
+    Task<VendorCategory> CreateVendorCategoryAsync(VendorCategory vendorCategory);
   }
 }

--- a/AgentSecure/Interfaces/IAgentSecureVendorCategoryService.cs
+++ b/AgentSecure/Interfaces/IAgentSecureVendorCategoryService.cs
@@ -10,5 +10,8 @@ namespace AgentSecure.Interfaces
     // Interfaces can be used in unit testing to mock out the actual implementation.
 
     // seed categories
+
+    // Create VendorCategory
+    Task<VendorCategory> CreateVendorCategoryAsync(VendorCategory vendorCategory);
   }
 }

--- a/AgentSecure/Repositories/AgentSecureCategoryRepository.cs
+++ b/AgentSecure/Repositories/AgentSecureCategoryRepository.cs
@@ -41,7 +41,7 @@ namespace AgentSecure.Repositories
     }
 
     // ✅ Update an existing category
-    public async Task<Category?> UpdateCategoryAsync(int id, Category category)
+    public async Task<Category> UpdateCategoryAsync(int id, Category category)
     {
       var existingCategory = await _context.Categories.FindAsync(id);
       if (existingCategory == null)
@@ -55,7 +55,7 @@ namespace AgentSecure.Repositories
     }
 
     // ✅ Delete a category
-    public async Task<Category?> DeleteCategoryAsync(int id)
+    public async Task<Category> DeleteCategoryAsync(int id)
     {
       var existingCategory = await _context.Categories.FindAsync(id);
       if (existingCategory != null)

--- a/AgentSecure/Repositories/AgentSecureVendorCategoryRepository.cs
+++ b/AgentSecure/Repositories/AgentSecureVendorCategoryRepository.cs
@@ -21,5 +21,17 @@ namespace AgentSecure.Repositories
     }
 
     // Seed data
+
+    // Create VendorCategory
+
+    public async Task<VendorCategory> CreateVendorCategoryAsync(VendorCategory vendorCategory)
+    {
+      _context.VendorCategories.Add(vendorCategory);
+      await _context.SaveChangesAsync();
+      return vendorCategory;
+    }
+
+    // Delete VendorCategory
+
   }
 }

--- a/AgentSecure/Services/AgentSecureVendorCategory.cs
+++ b/AgentSecure/Services/AgentSecureVendorCategory.cs
@@ -33,5 +33,13 @@ namespace AgentSecure.Services
     // To get the value, we use the await keyword.
 
     // seed data
+
+    // Create VendorCategory
+    public async Task<VendorCategory> CreateVendorCategoryAsync(VendorCategory vendorCategory)
+    {
+      return await _agentSecureVendorCategoryRepository.CreateVendorCategoryAsync(vendorCategory);
+    }
+
+    // Delete VendorCategory
   }
 }


### PR DESCRIPTION
**NOTE**

This branch was incorrectly named "get-allvendorcategories."  It should've been named "create-vendorcategory."


**Description**

Created CreateVendorCategoryAsync call


**Related Issue**

#19 


**Motivation and Context**

This call must be created in order for the VendorCategory join table to connect for API calls to be created for the Vendor and Category entities.


**How Can This Be Tested?**

Pull down and test manually


**Screenshots (if appropriate):**

N/A


**Types of changes**

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
