### PR TITLE
Fixed DeleteLoginAsync and DeleteVendorCategoryAsync calls

### DIFF
--- a/AgentSecure/Endpoints/LoginEndpoints.cs
+++ b/AgentSecure/Endpoints/LoginEndpoints.cs
@@ -60,13 +60,28 @@ namespace AgentSecure.Endpoint
       .Produces(StatusCodes.Status400BadRequest);
 
       // Delete Login
+      // group.MapDelete("/{id}", async (int id, IAgentSecureLoginService agentSecureLoginService) =>
+      // {
+      //   return await agentSecureLoginService.DeleteLoginAsync(id);
+      // })
+      // .WithName("DeleteLogin")
+      // .WithOpenApi()
+      // .Produces<Login>(StatusCodes.Status204NoContent);
+
       group.MapDelete("/{id}", async (int id, IAgentSecureLoginService agentSecureLoginService) =>
       {
-        return await agentSecureLoginService.DeleteLoginAsync(id);
+        var deletedLogin = await agentSecureLoginService.DeleteLoginAsync(id);
+        if (deletedLogin == null)
+        {
+          return Results.NotFound($"No Login found for Id {id}.");
+        }
+
+        return Results.NoContent();
       })
       .WithName("DeleteLogin")
       .WithOpenApi()
-      .Produces<Login>(StatusCodes.Status204NoContent);
+      .Produces<Login>(StatusCodes.Status204NoContent)
+      .Produces(StatusCodes.Status404NotFound);
     }
   }
 }

--- a/AgentSecure/Endpoints/VendorCategoryEndpoints.cs
+++ b/AgentSecure/Endpoints/VendorCategoryEndpoints.cs
@@ -11,14 +11,12 @@ namespace AgentSecure.Endpoint
     // The endpoint layer will call the service layer to process business logic.
     // The endpoint layer will return the data to the client.
     // The endpoint layer is the entry point for the client to access the application.
-    // We must register this MapWeatherEndpoints method in the Program.cs file.
+    // We must register this MapVendorCategoryEndpoints method in the Program.cs file.
     // You can click the reference to see where it is registered in the Program.cs file.
 
     public static void MapVendorCategoryEndpoints(this IEndpointRouteBuilder routes)
     {
       var group = routes.MapGroup("/api/vendorcategories").WithTags(nameof(VendorCategory));
-
-      // API calls
 
       // Create VendorCategory
       group.MapPost("/", async (VendorCategory vendorCategory, IAgentSecureVendorCategoryService agentSecureVendorCategoryService) =>
@@ -31,16 +29,20 @@ namespace AgentSecure.Endpoint
       .Produces(StatusCodes.Status400BadRequest);
 
       // Delete VendorCategory
+      group.MapDelete("/{id}", async (int id, IAgentSecureVendorCategoryService agentSecureVendorCategoryService) =>
+      {
+        var deletedVendorCategory = await agentSecureVendorCategoryService.DeleteVendorCategoryAsync(id);
+        if (deletedVendorCategory == null)
+        {
+          return Results.NotFound($"No VendorCategory found for Id {id}.");
+        }
 
-      group.MapDelete("/{id}", async (int id, IAgentSecureVendorCategoryService service) =>
-    {
-      await service.DeleteVendorCategoryAsync(id);
-      return Results.NoContent();
-    })
-    .WithName("DeleteVendorCategory")
-    .WithOpenApi()
-    .Produces(StatusCodes.Status204NoContent);
-
+        return Results.NoContent();
+      })
+      .WithName("DeleteVendorCategory")
+      .WithOpenApi()
+      .Produces(StatusCodes.Status204NoContent)
+      .Produces(StatusCodes.Status404NotFound);
     }
   }
 }


### PR DESCRIPTION
**Description**

Fixed DeleteLoginAsync and DeleteVendorCategoryAsync calls to show "204 No Content" instead of "200 Ok."


**Related Issue**

#14 #20 


**Motivation and Context**

The messages displayed after both of these delete calls should be "204 No Content" instead of "200 Ok."


**How Can This Be Tested?**

Pull down and test manually


**Screenshots (if appropriate):**

N/A


**Types of changes**

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
